### PR TITLE
Update Horse.Utils.ClientIP.pas

### DIFF
--- a/src/Horse.Utils.ClientIP.pas
+++ b/src/Horse.Utils.ClientIP.pas
@@ -23,6 +23,10 @@ begin
     if not Trim(LIP).IsEmpty then
       Exit(Trim(LIP));
 
+  for LIP in Trim(Req.Headers['x-forwarded-for']).Split([',']) do
+    if not Trim(LIP).IsEmpty then
+      Exit(Trim(LIP));
+
   if not Trim(Req.Headers['HTTP_X_FORWARDED']).IsEmpty then
     Exit(Trim(Req.Headers['HTTP_X_FORWARDED']));
 


### PR DESCRIPTION
The default name is "x-forwarded-for", HTTP_X_FORWARDED_FOR is used for PHP... but I'll keep it because I hasn't read enough 
Refs https://github.com/HashLoad/horse-logger/issues/4